### PR TITLE
Dumb SEO attempt

### DIFF
--- a/_layouts/game.html
+++ b/_layouts/game.html
@@ -4,7 +4,7 @@ layout: page
 
 {% assign game = page %}
 <div class="container text-center">
-  <h1>{{ game.long-name }}</h1>
+  <h1>{{ game.long-name }} <span style="display: none;">Randomizer</span></h1>
   <div class="row align-items-start justify-content-center">
     <div class="d-grid col-md-3 col-12">
       <img


### PR DESCRIPTION
This PR tries to do some (dumb) search engine optimization for the cases where people search for "{game} randomizer".
From looking at the results for a few games, the one websites that scored highest, always included "{game}" and "randomizer". The closer the terms were together, the higher they scored as they were more accurate to the query. 
I.e 
- Bash's github page, which is literally filled with `Metroid Prime Randomizer`
- various pypi and github projects such as `Cave Story Randomizer v2.0`, `randomizer patcher for Metroid Dread` etc.
- our project's github readme: `a randomizer [...] Metroid Dread. Metroid Prime 2: Echoes. [sic, dont ask me why prime1 isnt there]`

This lead me to notice:
1. We dont have any page where list both "randomizer" and all our supported games. However, I feel like putting that on the main page is distracting. We could put it on the about page, but I dont think pushing our about page is a good idea? Might be worth a shot tho in a later PR, since more clicks to our page => more chance of people downloading.
2. The pages that have "randomizer" and the games name in their main page, such as AM2R (`AM2R already has a built-in randomizer`) or MSR (`but in the randomizer, this has been changed`), do score relatively high


The solution? Include `Randomizer` on each game page, but in a way where it doesn't disrupt the flow of text. MDN mentions that headers get ranked higher for SEO.
So I just added it invisibly next to the game name.

Potential caveats: 
- Search engines *might* be smart enough to block invisibly styled elements. 
- Search engines will likely display the randomizer text, akin to this (inspector'd):
  ![grafik](https://github.com/randovania/randovania.github.io/assets/38186597/646bb4d3-e324-4985-b169-2d7ad36f652f)
- Certain things that ignore CSS properties (screen readers maybe? Esoteric text browsers?) will also display the randomizer text